### PR TITLE
Bump Massive Catalogs version to 0.1.0-alpha.40

### DIFF
--- a/buildSrc/src/main/kotlin/KtfmtVersion.kt
+++ b/buildSrc/src/main/kotlin/KtfmtVersion.kt
@@ -1,1 +1,1 @@
-internal const val KTFMT_VERSION: String = "0.26"
+internal const val KTFMT_VERSION: String = "0.27"

--- a/code-formatter/src/main/kotlin/KtfmtVersion.kt
+++ b/code-formatter/src/main/kotlin/KtfmtVersion.kt
@@ -1,1 +1,1 @@
-internal const val KTFMT_VERSION: String = "0.26"
+internal const val KTFMT_VERSION: String = "0.27"

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ allProjects.group=com.javiersc
 allProjects.name=gradle-plugins
 readmeBadges.mainProject=versioning
 dependencyDiscoveryLimit=stable
-massiveCatalogs=0.1.0-alpha.39
+massiveCatalogs=0.1.0-alpha.40
 ####################################################################################################
 ###                                           POM                                                ###
 ####################################################################################################


### PR DESCRIPTION
Changelog: https://massive-catalogs.javiersc.com/CHANGELOG/